### PR TITLE
Mudança de parametro para geração de boleto

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ moip.payment.create('ORD-SFGB23X8WAVQ', {
     fundingInstrument: {
         method: "BOLETO",
         boleto: {
-            expiration_date: "2017-09-30",
+            expirationDate: "2017-09-30",
             instruction_lines: {
                 first: "Primeira linha do boleto",
                 second: "Segunda linha do boleto",


### PR DESCRIPTION
o parametro 'expiration_date' não existe mais, substituido por 'expirationDate'

## Closing issue

- [ ] Issue number / Doesn't close any issue

## Checklist for this pull request

- [ ] Feature 1
- [ ] Feature 2

## Tests

- [ ] Feature 1
- [ ] Feature 2

